### PR TITLE
Enhance nav display in RTL version

### DIFF
--- a/src/app/[locale]/+components/Navigation/NavGroup.tsx
+++ b/src/app/[locale]/+components/Navigation/NavGroup.tsx
@@ -45,7 +45,7 @@ export const NavGroup = ({ text, children }: Props) => {
         {t(text)}
         <ChevronDownIcon />
       </button>
-      <div className="static top-full flex w-full flex-col gap-4 py-4 ps-2 desktop:absolute desktop:hidden desktop:ps-0 desktop:group-hover:flex rtl:gap-6 rtl:py-8 rtl:ps-4">
+      <div className="static top-full flex w-full flex-col gap-4 py-4 ps-2 desktop:absolute desktop:hidden desktop:ps-0 desktop:group-hover:flex rtl:ps-4">
         {children?.map((c) => (
           <NavLink key={c.href} {...c}>
             {t(c.text)}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -69,7 +69,7 @@ export default function LocaleLayout({ children, params }: Props) {
       >
         <JotaiProvider>
           <SupabaseProvider>
-            <div className="container flex w-full flex-col gap-24 py-8 text-base mobile:gap-40 desktop:py-40">
+            <div className="container flex w-full flex-col gap-24 py-8 text-base mobile:gap-44 desktop:py-40">
               <Header />
               {children}
               <Separator />


### PR DESCRIPTION
in the RTL version when hovering over the "جامعه" menu in the event page the sub-menu will go below the page title.
It's better to create a new UI but for now, it will fix it.

![Untitled](https://github.com/user-attachments/assets/8ef3237f-4063-49c8-a2c8-3c35a4cb1148)
