### PR TITLE
Add getReportWithCache / getReportWithoutCache functions

### DIFF
--- a/src/app/(wakatime)/day/page.tsx
+++ b/src/app/(wakatime)/day/page.tsx
@@ -1,11 +1,11 @@
-import { getReport } from '@/data-layer/wakatime/getReport';
+import { getReportWithoutCache } from '@/data-layer/wakatime/getReport';
 
 import { UserTable } from '../../[locale]/wakatime/+components/UserTable';
 import { Winner } from '../../[locale]/wakatime/+components/Winner';
 import Logo from './Logo.svg';
 
 export default async function WakatimeDay() {
-  const { day, year, usages, winners } = await getReport(7);
+  const { day, year, usages, winners } = await getReportWithoutCache(7);
 
   return (
     <body className="flex min-h-screen flex-col items-center overflow-x-hidden bg-bg-0 font-rajdhani text-base text-fg-0">

--- a/src/app/[locale]/wakatime/page.tsx
+++ b/src/app/[locale]/wakatime/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { generatePageOG } from '@/components/SEO';
 import { Separator } from '@/components/Separator';
 import { getServerFeature } from '@/config/features/getServerFeatures';
-import { getReport } from '@/data-layer/wakatime/getReport';
+import { getReportWithCache } from '@/data-layer/wakatime/getReport';
 
 import { Banner } from '../+components/Banner';
 import { Title } from './+components/Title';
@@ -22,7 +22,7 @@ export default async function WakatimePage() {
   const feature = getServerFeature('wakatime');
   if (!feature) return notFound();
 
-  const { day, year, usages, winners } = await getReport(50);
+  const { day, year, usages, winners } = await getReportWithCache(50);
 
   return (
     <>

--- a/src/data-layer/wakatime/getReport.tsx
+++ b/src/data-layer/wakatime/getReport.tsx
@@ -13,10 +13,7 @@ function toHumanHM(seconds: number) {
   return `${addLeadingZero(hours)}:${addLeadingZero(minutes)}`;
 }
 
-export const getReportWithCache = async (count: number) => {
-  'use cache';
-  cacheLife('hours');
-
+export const getReportWithoutCache = async (count: number) => {
   const url = joinPaths(
     serverConfig.get('wakatime.endpoint'),
     `day?size=${count}`,
@@ -53,39 +50,9 @@ export const getReportWithCache = async (count: number) => {
   };
 };
 
-export const getReportWithoutCache = async (count: number) => {
-  const url = joinPaths(
-    serverConfig.get('wakatime.endpoint'),
-    `day?size=${count}`,
-  );
-  const res = await fetch(joinPaths(url), { cache: 'no-cache' });
+export const getReportWithCache = async (count: number) => {
+  'use cache';
+  cacheLife('hours');
 
-  if (!res.ok)
-    throw new Error(
-      `Failed to fetch Wakatime report "${res.status}: ${res.statusText}"`,
-    );
-
-  const report = (await res.json()) as WakatimeReport;
-  const date = new Date(report.date);
-
-  const year = date.getFullYear();
-  const day = getDayOfYear(date);
-  const usages = report.usages.map<WakatimeUsage>((u) => {
-    return {
-      ...u,
-      humanReadableTotalSeconds: toHumanHM(u.totalSeconds),
-      humanReadableDailyAverage: toHumanHM(u.dailyAverage),
-      user: {
-        ...u.user,
-        ordinalRank: formatOrdinals(u.rank),
-      },
-    };
-  });
-
-  return {
-    year,
-    day,
-    winners: usages.slice(0, 3),
-    usages: usages.slice(3),
-  };
+  return getReportWithoutCache(count);
 };


### PR DESCRIPTION
Introduce two versions of getReport: one that uses caching (getReportWithCache) and one that always fetches fresh data (getReportWithoutCache). This makes Wakatime report fetching more flexible and configurable.