### PR TITLE
UI/Layout: Social icons are in middle of page on large screens instead of pinned to bottom

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -69,7 +69,7 @@ export default async function LocaleLayout({
             <div className="container flex min-h-screen w-full flex-col gap-24 py-8 text-base mobile:gap-44 desktop:py-40">
               <Header />
               {children}
-              <Separator />
+              <Separator className="mt-auto" />
               <Socials />
             </div>
           </SupabaseProvider>


### PR DESCRIPTION
On larger viewports, the social media icons float in the middle of the screen rather than staying to the bottom. This creates an awkward layout gap.

### Expected behavior
The social icons should be pushed to the bottom of the layout, keeping the main content visually balanced regardless of the screen height.

before:
<img width="2555" height="1267" alt="image" src="https://github.com/user-attachments/assets/e0af1ce2-e557-463e-b48e-babfbb0c90b4" />
after:
<img width="2557" height="1269" alt="image" src="https://github.com/user-attachments/assets/addf5631-bd2a-4653-b72c-43cbca494ee3" />
